### PR TITLE
Fix/user controller signup bad request

### DIFF
--- a/.g8/.g8.iml
+++ b/.g8/.g8.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/form/app" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/form/test" isTestSource="true" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/app/controllers/UserController.scala
+++ b/app/controllers/UserController.scala
@@ -8,17 +8,23 @@ import scala.concurrent.{ExecutionContext, Future}
 import play.api.libs.json._
 import play.api.data._
 import play.api.data.Forms._
+//Need to import Constraints to use Constraints
+import play.api.data.validation.Constraints._
 import org.mindrot.jbcrypt.BCrypt
 
 @Singleton
 class UserController @Inject()(cc: ControllerComponents, userDAO: UserDAO)(implicit ec: ExecutionContext) extends AbstractController(cc) {
 
-  val userForm: Form[User] = Form(
+  private val passwordRegex = """^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,}$""".r
+
+  private val userForm: Form[User] = Form(
     mapping(
       "id" -> optional(longNumber),
       "username" -> nonEmptyText(minLength = 3, maxLength = 20),
       "email" -> email,
-      "password" -> nonEmptyText
+      "password" -> nonEmptyText(minLength = 8).verifying(
+        pattern(passwordRegex, error = "Password must contain at least one letter and one number"
+      ))
     )(User.apply)(User.unapply)
   )
 

--- a/app/controllers/UserController.scala
+++ b/app/controllers/UserController.scala
@@ -27,17 +27,31 @@ class UserController @Inject()(cc: ControllerComponents, userDAO: UserDAO)(impli
   }
 
   def signUp = Action.async(parse.json) { implicit request =>
+    // Retrieve the data from the JSON
+    // Get the username, email, and password
     val json = request.body.as[JsObject]
     val username = (json \ "username").as[String]
     val email = (json \ "email").as[String]
     val password = (json \ "password").as[String]
 
-    val user = User(None, username, email, password)
+    if (username.isEmpty || email.isEmpty || password.isEmpty) {
+      Future.successful(BadRequest(Json.obj("status" -> "error", "message" -> "Invalid Input Data")))
+    } else {
+      // Use that data to create a new user object
+      val user = User(None, username, email, password)
 
-    userDAO.addUser(user).map { id =>
-      Created(Json.obj("status" -> "success", "message" -> s"User $id created"))
-    }.recover {
-      case _ => InternalServerError(Json.obj("status" -> "error", "message" -> "User could not be created"))
+      // Doing something with the DAO, I suspect its related to slick and how it communicates with the DB
+      // Call the addUser method and then map the result? using the 'Created' method from the Play framework
+      // IDE says Created does "Generates a ‘201 CREATED’ result."
+      // .recover seems similar to the 'catch' block found in other languages
+      // uses "case _" to match anything "throwable" from the "future" and sends it to the InternalServerError
+      // "InternalServerError" seems to be a method from the Play framework
+      // IDE says "Generates a ‘500 INTERNAL_SERVER_ERROR’ result."
+      userDAO.addUser(user).map { id =>
+        Created(Json.obj("status" -> "success", "message" -> s"User $id created"))
+      }.recover {
+        case _ => InternalServerError(Json.obj("status" -> "error", "message" -> "User could not be created"))
+      }
     }
   }
 

--- a/app/daos/UserDAO.scala
+++ b/app/daos/UserDAO.scala
@@ -14,7 +14,15 @@ class UserDAO @Inject()(dbConfigProvider: DatabaseConfigProvider)(implicit ec: E
   import dbConfig._
   import profile.api._
 
+  //Gets all the users from the DB
   val users = Users.table
+
+  //Method returns a Future which I guess is like Promise
+  //It uses the password property of the user to hash pw with Bcrypt
+  //Then creates a new user instance shallow copy using Scala's .copy method
+  //Replaces the password property value with the new hashed password.
+  //Uses slick's run() method to add the new user to the Table
+  //It adds to the user table by first retrieving all the users and then mapping with +=
 
   def addUser(user: User): Future[Long] = {
     val hashedPassword = BCrypt.hashpw(user.password, BCrypt.gensalt())

--- a/app/daos/UserDAO.scala
+++ b/app/daos/UserDAO.scala
@@ -17,13 +17,6 @@ class UserDAO @Inject()(dbConfigProvider: DatabaseConfigProvider)(implicit ec: E
   //Gets all the users from the DB
   val users = Users.table
 
-  //Method returns a Future which I guess is like Promise
-  //It uses the password property of the user to hash pw with Bcrypt
-  //Then creates a new user instance shallow copy using Scala's .copy method
-  //Replaces the password property value with the new hashed password.
-  //Uses slick's run() method to add the new user to the Table
-  //It adds to the user table by first retrieving all the users and then mapping with +=
-
   def addUser(user: User): Future[Long] = {
     val hashedPassword = BCrypt.hashpw(user.password, BCrypt.gensalt())
     val userWithHashedPassword = user.copy(password = hashedPassword)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -3,8 +3,8 @@
 # Development database configuration
 db.default.driver = org.postgresql.Driver
 db.default.url = "jdbc:postgresql://localhost:5432/the_makers_store_dev"
-db.default.username = "username"
-db.default.password = "password"
+db.default.username = "alangardiner"
+db.default.password = ""
 
 # Play Slick Configuration
 slick.dbs.default.profile = "slick.jdbc.PostgresProfile$"

--- a/test/controllers/UserControllerSpec.scala
+++ b/test/controllers/UserControllerSpec.scala
@@ -46,6 +46,11 @@ class UserControllerSpec extends PlaySpec with GuiceOneAppPerTest with Injecting
       maybeUser.get.email mustBe "test@example.com"
     }
 
+    //In order to trigger the .recover block, we need to throw some error in the addUser() method or the "Created".
+    //We don't have control over Created, so we only have control of the userDao file and the User model.
+    //1. We could return an error when creating a User object.
+    //2. We could return an error when addUser()
+    //3. Check that the received JSON contains necessary fields before even instantiating the User object
     "return bad request for invalid data" in {
       val userDAO = inject[UserDAO]
       val userController = new UserController(stubControllerComponents(), userDAO)(inject[ExecutionContext])

--- a/test/controllers/UserControllerSpec.scala
+++ b/test/controllers/UserControllerSpec.scala
@@ -22,7 +22,9 @@ class UserControllerSpec extends PlaySpec with GuiceOneAppPerTest with Injecting
   "UserController POST /signUp" should {
 
     "create a new user" in {
+      //Inject an instance of UserDao to our controller
       val userDAO = inject[UserDAO]
+      //Uses something called stubControllerComponents() from Play
       val userController = new UserController(stubControllerComponents(), userDAO)(inject[ExecutionContext])
 
       val request = FakeRequest(POST, "/signUp")
@@ -51,6 +53,9 @@ class UserControllerSpec extends PlaySpec with GuiceOneAppPerTest with Injecting
     //1. We could return an error when creating a User object.
     //2. We could return an error when addUser()
     //3. Check that the received JSON contains necessary fields before even instantiating the User object
+
+    //Email should match this: .+@example\.com
+    //Password: [0-9a-fA-F]{4,8}
     "return bad request for invalid data" in {
       val userDAO = inject[UserDAO]
       val userController = new UserController(stubControllerComponents(), userDAO)(inject[ExecutionContext])
@@ -64,7 +69,6 @@ class UserControllerSpec extends PlaySpec with GuiceOneAppPerTest with Injecting
         .withCSRFToken
 
       val result = call(userController.signUp, request)
-
       status(result) mustBe BAD_REQUEST
     }
   }

--- a/test/controllers/UserControllerSpec.scala
+++ b/test/controllers/UserControllerSpec.scala
@@ -31,7 +31,7 @@ class UserControllerSpec extends PlaySpec with GuiceOneAppPerTest with Injecting
         .withJsonBody(Json.obj(
           "username" -> "testuser",
           "email" -> "test@example.com",
-          "password" -> "password")
+          "password" -> "Password1")
         )
         .withCSRFToken
 


### PR DESCRIPTION
## Description

User could sign up to service with invalid data. No http 400 Bad Request was returned. 
Wrote validation in the UserController under the signUp() method to validate form data before running business logic and interaction with DB. 

## Learnt:
### If/Else Type Safety
Scala Type safety means that returned data from **if/else** blocks must be consistent across both blocks (i.e. if returns INT, else returns INT). In this case, .recover() in the else block expected a Future[Result], so the **if** block must adhere to the same return type. 

### Futures
**Future.failed()** returns type **Future[Throwable]**. This can be resolved to a Future[Result] if it is caught at a higher level by .recover(). 

### Scala Play Form Validations
Scala Play has built-in form validation and something called **constraints**. You need to import:
`import play.api.data.Forms._`
`import play.api.data.validation.Constraints._`
Read about them [here](https://www.playframework.com/documentation/3.0.x/ScalaForms#Validating-a-form-in-an-Action)