### PR TITLE
Fix/user controller test teardown

### DIFF
--- a/test/controllers/UserControllerSpec.scala
+++ b/test/controllers/UserControllerSpec.scala
@@ -2,11 +2,13 @@ package controllers
 
 import daos.UserDAO
 import models.Users
+import org.scalatest.BeforeAndAfterEach
 import org.scalatestplus.play._
 import org.scalatestplus.play.guice._
+import play.api.Application
 import play.api.Play.materializer
+import play.api.db.evolutions.Evolutions
 import play.api.db.slick.DatabaseConfigProvider
-import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.Json
 import play.api.test.CSRFTokenHelper.CSRFRequest
 import play.api.test.Helpers._
@@ -14,10 +16,33 @@ import play.api.test._
 import slick.jdbc.JdbcProfile
 import slick.lifted
 import slick.lifted.TableQuery
+import play.api.db.{DBApi, Database}
+import play.api.inject.Injector
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.{Play, Application}
 
 import scala.concurrent.ExecutionContext
 
-class UserControllerSpec extends PlaySpec with GuiceOneAppPerTest with Injecting {
+
+class UserControllerSpec extends PlaySpec with GuiceOneAppPerTest with Injecting with BeforeAndAfterEach {
+
+  // WithApplication - Play Framework utility to manage application lifecycle during testing. Fresh app instance for
+  // each test and running the evolutions
+  // Play Evolutions - Scripts that manage database schema changes.
+  // Slick - Database query and access library.
+
+    def fakeApp(): Application = new GuiceApplicationBuilder().build()
+    lazy val database: Database = fakeApp().injector.instanceOf[DBApi].database("default")
+
+    override def beforeEach(): Unit = {
+//      Evolutions.cleanupEvolutions(database)
+      Evolutions.applyEvolutions(database)
+    }
+
+    override def afterEach(): Unit = {
+       Evolutions.cleanupEvolutions(database)
+      // can put cleanup in here instead but kept in beforeEach so table structure is kept in db
+    }
 
   "UserController POST /signUp" should {
 

--- a/test/controllers/UserControllerSpec.scala
+++ b/test/controllers/UserControllerSpec.scala
@@ -6,9 +6,10 @@ import org.scalatest.BeforeAndAfterEach
 import org.scalatestplus.play._
 import org.scalatestplus.play.guice._
 import play.api.Application
+import play.api.db.slick.DatabaseConfigProvider
+import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.Play.materializer
 import play.api.db.evolutions.Evolutions
-import play.api.db.slick.DatabaseConfigProvider
 import play.api.libs.json.Json
 import play.api.test.CSRFTokenHelper.CSRFRequest
 import play.api.test.Helpers._
@@ -17,9 +18,6 @@ import slick.jdbc.JdbcProfile
 import slick.lifted
 import slick.lifted.TableQuery
 import play.api.db.{DBApi, Database}
-import play.api.inject.Injector
-import play.api.inject.guice.GuiceApplicationBuilder
-import play.api.{Play, Application}
 
 import scala.concurrent.ExecutionContext
 
@@ -31,18 +29,19 @@ class UserControllerSpec extends PlaySpec with GuiceOneAppPerTest with Injecting
   // Play Evolutions - Scripts that manage database schema changes.
   // Slick - Database query and access library.
 
-    def fakeApp(): Application = new GuiceApplicationBuilder().build()
-    lazy val database: Database = fakeApp().injector.instanceOf[DBApi].database("default")
+  def fakeApp(): Application = new GuiceApplicationBuilder().build()
 
-    override def beforeEach(): Unit = {
-//      Evolutions.cleanupEvolutions(database)
-      Evolutions.applyEvolutions(database)
-    }
+  lazy val database: Database = fakeApp().injector.instanceOf[DBApi].database("default")
 
-    override def afterEach(): Unit = {
-       Evolutions.cleanupEvolutions(database)
-      // can put cleanup in here instead but kept in beforeEach so table structure is kept in db
-    }
+  override def beforeEach(): Unit = {
+    //      Evolutions.cleanupEvolutions(database)
+    Evolutions.applyEvolutions(database)
+  }
+
+  override def afterEach(): Unit = {
+    Evolutions.cleanupEvolutions(database)
+    // can put cleanup in here instead but kept in beforeEach so table structure is kept in db
+  }
 
   "UserController POST /signUp" should {
 


### PR DESCRIPTION
## Description

Tried to fix the issue with the test not tearing down after each test case. 
I tried to follow the documentation in [Writing Function Tests](https://www.playframework.com/documentation/3.0.x/ScalaFunctionalTestingWithScalaTest)
and [Testing with Database](https://www.playframework.com/documentation/3.0.x/ScalaTestingWithDatabases#Applying-evolutions). 
In the end I couldn't get it working and I'm not sure why. Its something to do with GuiceOneAppPerTest returning a NullPointerException and I think it happens because I'm trying to do some test set up with "beforeEach" and "afterEach". Perhaps app is not available?

In the end a peer shared a code snippet showing how to manually get the app from GuiceApplicationBuilder and using that to run the test. 